### PR TITLE
Introduce coding standards workflow

### DIFF
--- a/workflow-templates/coding-standards.properties.json
+++ b/workflow-templates/coding-standards.properties.json
@@ -1,0 +1,11 @@
+{
+    "name": "Coding standards",
+    "description": "Enforces Doctrine Coding Standard",
+    "iconName": "doctrine-logo",
+    "categories": [
+        "PHP"
+    ],
+    "filePatterns": [
+        "^phpcs\\.xml(?:\\.dist)$"
+    ]
+}

--- a/workflow-templates/coding-standards.yml
+++ b/workflow-templates/coding-standards.yml
@@ -1,0 +1,39 @@
+
+name: "Coding Standards"
+
+on: ["pull_request", "push"]
+
+jobs:
+  coding-standards:
+    name: "Coding Standards"
+    runs-on: "ubuntu-20.04"
+
+    strategy:
+      matrix:
+        php-version:
+          - "7.4"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
+          tools: "cs2pr"
+
+      - name: "Cache dependencies installed with Composer"
+        uses: "actions/cache@v2"
+        with:
+          path: "~/.composer/cache"
+          key: "php-${{ matrix.php-version }}-composer-locked-${{ hashFiles('composer.lock') }}"
+          restore-keys: "php-${{ matrix.php-version }}-composer-locked-"
+
+      - name: "Install dependencies with Composer"
+        run: "composer install --no-interaction --no-progress --no-suggest"
+
+      # https://github.com/doctrine/.github/issues/3
+      - name: "Run PHP_CodeSniffer"
+        run: "vendor/bin/phpcs -q --no-colors --report=checkstyle | cs2pr"

--- a/workflow-templates/doctrine-logo.svg
+++ b/workflow-templates/doctrine-logo.svg
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (https://inkscape.org/) -->
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://inkscape.org/namespaces/inkscape/" width="172.231" height="225.83495" id="svg2" version="1.1" inkscape:version="0.48.3.1 r9886" sodipodi:docname="disegno-1.svg">
+  <defs id="defs4"/>
+  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="2.8284271" inkscape:cx="130.76444" inkscape:cy="78.716969" inkscape:document-units="px" inkscape:current-layer="layer2" showgrid="false" showguides="true" inkscape:guide-bbox="true" inkscape:window-width="1920" inkscape:window-height="1056" inkscape:window-x="0" inkscape:window-y="24" inkscape:window-maximized="1" fit-margin-top="0" fit-margin-left="0" fit-margin-right="0" fit-margin-bottom="0">
+    <sodipodi:guide orientation="1,0" position="61.255508,48.339011" id="guide3932"/>
+    <sodipodi:guide orientation="0,1" position="132.008,86.819454" id="guide3938"/>
+  </sodipodi:namedview>
+  <metadata id="metadata7">
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <dc:title/>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g inkscape:groupmode="layer" id="layer2" inkscape:label="Livello" style="display:inline" transform="translate(-213.6027,-388.59008)">
+    <path sodipodi:type="arc" style="fill:#fc6a31;fill-opacity:1;stroke:none" id="path3000" sodipodi:cx="322.49121" sodipodi:cy="549.55878" sodipodi:rx="86.115501" sodipodi:ry="86.115501" d="m 408.60671,549.55878 a 86.115501,86.115501 0 1 1 -1.0902,-13.65934" sodipodi:start="0" sodipodi:end="6.1238961" sodipodi:open="true" transform="translate(-22.587596,-21.249244)"/>
+    <path style="fill:#fc6a31;fill-opacity:1;stroke:none" d="m 279.57221,447.50288 -24.36993,-22.98097 29.04189,-30.17831 76.00246,72.51444 z" id="path3004" inkscape:connector-curvature="0" sodipodi:nodetypes="ccccc"/>
+    <path sodipodi:type="arc" style="fill:#fc6a31;fill-opacity:1;stroke:none" id="path3778" sodipodi:cx="267.05283" sodipodi:cy="413.7959" sodipodi:rx="18.365086" sodipodi:ry="18.365086" d="m 285.41791,413.7959 a 18.365086,18.365086 0 1 1 -0.2325,-2.91301" sodipodi:start="0" sodipodi:end="6.1238961" sodipodi:open="true" transform="matrix(1.1386667,0,0,1.1386667,-34.276316,-61.673814)"/>
+  </g>
+  <g inkscape:groupmode="layer" id="layer3" inkscape:label="Livello#1" transform="translate(-213.6027,-388.59008)">
+    <path style="fill:#ffffff;fill-opacity:1;stroke:none" d="m 301.18536,514.77324 -22.37068,-22.37068 19.94069,-19.47166 46.21439,46.46752 c 0,0.0382 0.007,16.40677 0.007,16.40677 l -46.14656,46.56491 -19.80809,-19.8081 22.78623,-22.78623 -47.30395,0 -0.1166,-25.02445 c 15.59855,0.0527 31.19832,0.0219 46.79722,0.0219 z" id="path3821" inkscape:connector-curvature="0" sodipodi:nodetypes="cccccccccccc"/>
+    <path sodipodi:type="arc" style="fill:#ffffff;fill-opacity:1;stroke:none" id="path3831" sodipodi:cx="241.37886" sodipodi:cy="526.97913" sodipodi:rx="12.779366" sodipodi:ry="12.779366" d="m 254.15823,526.97913 a 12.779366,12.779366 0 1 1 -0.16179,-2.02702" sodipodi:start="0" sodipodi:end="6.1238961" sodipodi:open="true" transform="matrix(0.97849458,0,0,0.97849458,18.177595,11.607714)"/>
+    <path sodipodi:type="arc" style="fill:#ffffff;fill-opacity:1;stroke:none" id="path3831-9" sodipodi:cx="241.37886" sodipodi:cy="526.97913" sodipodi:rx="12.779366" sodipodi:ry="12.779366" d="m 254.15823,526.97913 a 12.779366,12.779366 0 1 1 -0.16179,-2.02702" sodipodi:start="0" sodipodi:end="6.1238961" sodipodi:open="true" transform="matrix(1.0929243,0,0,1.0902632,25.159677,-91.677055)"/>
+    <path sodipodi:type="arc" style="fill:#ffffff;fill-opacity:1;stroke:none" id="path3831-9-1" sodipodi:cx="241.37886" sodipodi:cy="526.97913" sodipodi:rx="12.779366" sodipodi:ry="12.779366" d="m 254.15823,526.97913 a 12.779366,12.779366 0 1 1 -0.16179,-2.02702" sodipodi:start="0" sodipodi:end="6.1238961" sodipodi:open="true" transform="matrix(1.0967528,0,0,1.0940824,24.141072,-4.0394917)"/>
+    <path sodipodi:type="arc" style="fill:#ffffff;fill-opacity:1;stroke:none" id="path3831-97" sodipodi:cx="241.37886" sodipodi:cy="526.97913" sodipodi:rx="12.779366" sodipodi:ry="12.779366" d="m 254.15823,526.97913 a 12.779366,12.779366 0 1 1 -0.16179,-2.02702" sodipodi:start="0" sodipodi:end="6.1238961" sodipodi:open="true" transform="matrix(0.97849458,0,0,0.97849458,99.351975,11.959353)"/>
+  </g>
+</svg>


### PR DESCRIPTION
This is a copy of the coding standards workflow I introduced in `doctrine/annotations`, with a few changes:
- consistent use of coding standards, and in case we add more jobs
- use of actions/cache v2 (I forgot to use it in `doctrine/annotations`
- I renamed the last step, which still wrongly references phpcbf

I'm deliberately naming the file with a very narrow scope, so that it's easy to enable or disable workflows based on the repository we are using.