### PR TITLE
Use appropriate case for git

### DIFF
--- a/workflow-templates/release-on-milestone-closed.yml
+++ b/workflow-templates/release-on-milestone-closed.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release:
-    name: "GIT tag, release & create merge-up PR"
+    name: "Git tag, release & create merge-up PR"
     runs-on: "ubuntu-20.04"
 
     steps:


### PR DESCRIPTION
That name is not an acronym.

Pointed out by @morozov in https://github.com/doctrine/dbal/pull/4251#discussion_r487553228