### PR TITLE
Drop milestone creation step

### DIFF
--- a/workflow-templates/release-on-milestone-closed.yml
+++ b/workflow-templates/release-on-milestone-closed.yml
@@ -43,13 +43,3 @@ jobs:
           "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
           "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
-
-      - name: "Create new milestones"
-        uses: "laminas/automatic-releases@v1"
-        with:
-          command-name: "laminas:automatic-releases:create-milestones"
-        env:
-          "GITHUB_TOKEN": ${{ secrets.GITHUB_TOKEN }}
-          "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
-          "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
-          "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}


### PR DESCRIPTION
The case when you do not need a milestone (because it is the end of the
branch) is not handled: closing what you intend to be the last milestone of a branch will create another milestone, which you have to close manually which would not create another milestone itself because the closed milestone would be empty.

Pointed out by @morozov in https://github.com/doctrine/dbal/pull/4251#issuecomment-691507219
Asked about at https://discourse.laminas.dev/t/laminas-automatic-releases-how-do-you-stop-the-milestones/1824
Also discussed in resolved discussion at https://github.com/doctrine/dbal/pull/4251#discussion_r487434321