### PR TITLE
Use v1 tag for all steps

### DIFF
--- a/workflow-templates/release-on-milestone-closed.yml
+++ b/workflow-templates/release-on-milestone-closed.yml
@@ -15,7 +15,7 @@ jobs:
         uses: "actions/checkout@v2"
 
       - name: "Release"
-        uses: "laminas/automatic-releases@1.0.1"
+        uses: "laminas/automatic-releases@v1"
         with:
           command-name: "laminas:automatic-releases:release"
         env:
@@ -25,7 +25,7 @@ jobs:
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
 
       - name: "Create Merge-Up Pull Request"
-        uses: "laminas/automatic-releases@1.0.1"
+        uses: "laminas/automatic-releases@v1"
         with:
           command-name: "laminas:automatic-releases:create-merge-up-pull-request"
         env:


### PR DESCRIPTION
As pointed out by @stof  on [Slack](https://doctrine.slack.com/archives/GERFT2W5T/p1600331136227100), we are building the image
twice because we are using different versions. Moreover, the example has
been updated upstream to always use v1. That tag will be a moving
pointing to the latest version.

More details at https://github.com/laminas/automatic-releases/pull/38