### PR TITLE
Restrict CS workflow to release branches

### DIFF
--- a/workflow-templates/coding-standards.yml
+++ b/workflow-templates/coding-standards.yml
@@ -1,7 +1,15 @@
 
 name: "Coding Standards"
 
-on: ["pull_request", "push"]
+on:
+  pull_request:
+    branches:
+      - "*.x"
+      - "master"
+  push:
+    branches:
+      - "*.x"
+      - "master"
 
 jobs:
   coding-standards:


### PR DESCRIPTION
We do not want to see coding standard-related jobs twice when we make a
pull request from origin to origin.