### PR TITLE
Comment out step that switches to the new branch

### DIFF
--- a/workflow-templates/release-on-milestone-closed.yml
+++ b/workflow-templates/release-on-milestone-closed.yml
@@ -34,15 +34,18 @@ jobs:
           "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
           "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
 
-      - name: "Create and/or Switch to new Release Branch"
-        uses: "laminas/automatic-releases@v1"
-        with:
-          command-name: "laminas:automatic-releases:switch-default-branch-to-next-minor"
-        env:
-          "GITHUB_TOKEN": ${{ secrets.ORGANIZATION_ADMIN_TOKEN }}
-          "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
-          "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
-          "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
+      # Uncomment this step if the repository uses a "next minor as default
+      # branch" policy.
+      #
+      # - name: "Create and/or Switch to new Release Branch"
+      #   uses: "laminas/automatic-releases@v1"
+      #   with:
+      #     command-name: "laminas:automatic-releases:switch-default-branch-to-next-minor"
+      #   env:
+      #     "GITHUB_TOKEN": ${{ secrets.ORGANIZATION_ADMIN_TOKEN }}
+      #     "SIGNING_SECRET_KEY": ${{ secrets.SIGNING_SECRET_KEY }}
+      #     "GIT_AUTHOR_NAME": ${{ secrets.GIT_AUTHOR_NAME }}
+      #     "GIT_AUTHOR_EMAIL": ${{ secrets.GIT_AUTHOR_EMAIL }}
 
       - name: "Create new milestones"
         uses: "laminas/automatic-releases@v1"


### PR DESCRIPTION
We decided in https://github.com/orgs/doctrine/teams/doctrinecore/discussions/19
that the default branch should be the lowest one in order to make
retargeting branches easier, with the exception of some repositories
that may keep that particular step.