### PR TITLE
Allow to install dev dependencies with psalm

### DIFF
--- a/workflow-templates/static-analysis.yml
+++ b/workflow-templates/static-analysis.yml
@@ -60,3 +60,6 @@ jobs:
 
       - name: Psalm
         uses: docker://vimeo/psalm-github-actions
+        # Uncomment this part in order to install dev dependencies before executing psalm
+        # with:
+        #  composer_require_dev: true


### PR DESCRIPTION
This parameter should be set in order to install dev dependencies before running psalm. See https://github.com/psalm/psalm-github-actions#customising-composer.