### PR TITLE
Remove "--no-suggest" option from Composer commands

### DIFF
--- a/workflow-templates/coding-standards.yml
+++ b/workflow-templates/coding-standards.yml
@@ -40,7 +40,7 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-composer-locked-"
 
       - name: "Install dependencies with Composer"
-        run: "composer install --no-interaction --no-progress --no-suggest"
+        run: "composer install --no-interaction --no-progress"
 
       # https://github.com/doctrine/.github/issues/3
       - name: "Run PHP_CodeSniffer"

--- a/workflow-templates/static-analysis.yml
+++ b/workflow-templates/static-analysis.yml
@@ -40,7 +40,7 @@ jobs:
           restore-keys: "php-${{ matrix.php-version }}-composer-locked-"
 
       - name: "Install dependencies with composer"
-        run: "composer install --no-interaction --no-progress --no-suggest"
+        run: "composer install --no-interaction --no-progress"
 
       - name: "Run a static analysis with phpstan/phpstan"
         run: "vendor/bin/phpstan analyse --error-format=checkstyle | cs2pr"


### PR DESCRIPTION
As it is deprecated in Composer 2:

> ```You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.```