### PR TITLE
Stop piping phpstan into cs2pr

### DIFF
--- a/workflow-templates/static-analysis.yml
+++ b/workflow-templates/static-analysis.yml
@@ -30,7 +30,6 @@ jobs:
         with:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
-          tools: "cs2pr"
 
       - name: "Cache dependencies installed with composer"
         uses: "actions/cache@v2"
@@ -43,7 +42,7 @@ jobs:
         run: "composer install --no-interaction --no-progress"
 
       - name: "Run a static analysis with phpstan/phpstan"
-        run: "vendor/bin/phpstan analyse --error-format=checkstyle | cs2pr"
+        run: "vendor/bin/phpstan analyse"
 
   static-analysis-psalm:
     name: "Static Analysis with Psalm"


### PR DESCRIPTION
Recent versions of PHPStan have native supports for Github Actions.