### PR TITLE
Ditch docker-based action, reuse vendor binary

### DIFF
--- a/workflow-templates/static-analysis.yml
+++ b/workflow-templates/static-analysis.yml
@@ -54,8 +54,24 @@ jobs:
           - "7.4"
 
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+      - name: "Checkout code"
+        uses: "actions/checkout@v2"
 
-      - name: Psalm
-        uses: docker://vimeo/psalm-github-actions
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
+
+      - name: "Cache dependencies installed with composer"
+        uses: "actions/cache@v2"
+        with:
+          path: "~/.composer/cache"
+          key: "php-${{ matrix.php-version }}-composer-locked-${{ hashFiles('composer.lock') }}"
+          restore-keys: "php-${{ matrix.php-version }}-composer-locked-"
+
+      - name: "Install dependencies with composer"
+        run: "composer install --no-interaction --no-progress"
+
+      - name: "Run a static analysis with vimeo/psalm"
+        run: "vendor/bin/psalm --show-info=false --stats --output-format=github --threads=$(nproc)"


### PR DESCRIPTION
Although this is far more code, doing this should allow us to be sure
that vendor/bin/psalm runs without errors in dev, and that we use the
same version in both environments.