### PR TITLE
Use the ramsey/composer-install action to install dependencies

### DIFF
--- a/workflow-templates/coding-standards.yml
+++ b/workflow-templates/coding-standards.yml
@@ -32,15 +32,8 @@ jobs:
           php-version: "${{ matrix.php-version }}"
           tools: "cs2pr"
 
-      - name: "Cache dependencies installed with Composer"
-        uses: "actions/cache@v2"
-        with:
-          path: "~/.composer/cache"
-          key: "php-${{ matrix.php-version }}-composer-locked-${{ hashFiles('composer.lock') }}"
-          restore-keys: "php-${{ matrix.php-version }}-composer-locked-"
-
       - name: "Install dependencies with Composer"
-        run: "composer install --no-interaction --no-progress"
+        uses: "ramsey/composer-install@v1"
 
       # https://github.com/doctrine/.github/issues/3
       - name: "Run PHP_CodeSniffer"

--- a/workflow-templates/static-analysis.yml
+++ b/workflow-templates/static-analysis.yml
@@ -31,15 +31,8 @@ jobs:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
 
-      - name: "Cache dependencies installed with composer"
-        uses: "actions/cache@v2"
-        with:
-          path: "~/.composer/cache"
-          key: "php-${{ matrix.php-version }}-composer-locked-${{ hashFiles('composer.lock') }}"
-          restore-keys: "php-${{ matrix.php-version }}-composer-locked-"
-
-      - name: "Install dependencies with composer"
-        run: "composer install --no-interaction --no-progress"
+      - name: "Install dependencies with Composer"
+        uses: "ramsey/composer-install@v1"
 
       - name: "Run a static analysis with phpstan/phpstan"
         run: "vendor/bin/phpstan analyse"
@@ -63,15 +56,8 @@ jobs:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
 
-      - name: "Cache dependencies installed with composer"
-        uses: "actions/cache@v2"
-        with:
-          path: "~/.composer/cache"
-          key: "php-${{ matrix.php-version }}-composer-locked-${{ hashFiles('composer.lock') }}"
-          restore-keys: "php-${{ matrix.php-version }}-composer-locked-"
-
-      - name: "Install dependencies with composer"
-        run: "composer install --no-interaction --no-progress"
+      - name: "Install dependencies with Composer"
+        uses: "ramsey/composer-install@v1"
 
       - name: "Run a static analysis with vimeo/psalm"
         run: "vendor/bin/psalm --show-info=false --stats --output-format=github --threads=$(nproc)"


### PR DESCRIPTION
While migrating doctrine/data-fixtures from Travis CI to GitHub Actions (https://github.com/doctrine/data-fixtures/pull/353), looking for an elegant way to add a job with the lowest dependency versions I came across the [composer-install action](https://github.com/marketplace/actions/install-composer-dependencies) made by @ramsey.

This action makes it easy to choose between installing locked versions (`composer install`), highest versions (`composer update`), and lowest versions (`composer update --prefer-lowest`). The `--no-interaction`, `--no-progress`, and `--ansi` flags are automatically added to the command. It also handles caching of dependencies to improve build times.

In other words, something like this:

```yaml
      - name: "Cache dependencies installed with composer"
        uses: "actions/cache@v2"
        with:
          path: "~/.composer/cache"
          key: "php-${{ matrix.php-version }}-composer-locked-${{ hashFiles('composer.lock') }}"
          restore-keys: "php-${{ matrix.php-version }}-composer-locked-"

      - name: "Install dependencies with composer"
        run: "composer update --no-interaction --no-progress --no-suggest"
        if: "${{ matrix.dependencies == 'highest' }}"

      - name: "Install lowest possible dependencies with composer"
        run: "composer update --no-interaction --no-progress --no-suggest --prefer-dist --prefer-lowest"
        if: "${{ matrix.dependencies == 'lowest' }}"
```

can be rewritten to this:

```yaml
      - name: "Install dependencies with composer"
        uses: "ramsey/composer-install@v1"
        with:
          dependency-versions: "${{ matrix.dependencies }}"
          composer-options: "--prefer-dist --no-suggest"
```

I believe this greatly improves the readability and maintainability of GitHub Actions workflows in the Doctrine organization.

As [suggested](https://github.com/doctrine/data-fixtures/pull/353#discussion_r536646473) by @greg0ire I'm opening this PR to discuss the usage of this GitHub Action on an organization level.