### PR TITLE
Create a Continuous Integration workflow template

### DIFF
--- a/workflow-templates/continuous-integration.properties.json
+++ b/workflow-templates/continuous-integration.properties.json
@@ -1,0 +1,11 @@
+{
+    "name": "Continuous Integration",
+    "description": "Runs automated tests on multiple PHP versions",
+    "iconName": "doctrine-logo",
+    "categories": [
+        "PHP"
+    ],
+    "filePatterns": [
+        "^phpunit\\.xml(?:\\.dist)$"
+    ]
+}

--- a/workflow-templates/continuous-integration.yml
+++ b/workflow-templates/continuous-integration.yml
@@ -37,11 +37,11 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: "Install PHP with Xdebug"
+      - name: "Install PHP"
         uses: "shivammathur/setup-php@v2"
         with:
           php-version: "${{ matrix.php-version }}"
-          coverage: "xdebug"
+          coverage: "pcov"
           ini-values: "zend.assertions=1"
 
       - name: "Install dependencies with Composer"

--- a/workflow-templates/continuous-integration.yml
+++ b/workflow-templates/continuous-integration.yml
@@ -1,0 +1,82 @@
+name: "Continuous Integration"
+
+on:
+  pull_request:
+    branches:
+      - "*.x"
+      - "master"
+  push:
+    branches:
+      - "*.x"
+      - "master"
+
+env:
+  fail-fast: true
+
+jobs:
+  phpunit:
+    name: "PHPUnit"
+    runs-on: "ubuntu-20.04"
+
+    strategy:
+      matrix:
+        php-version:
+          - "7.2"
+          - "7.3"
+          - "7.4"
+          - "8.0"
+        dependencies:
+          - "highest"
+        include:
+          - php-version: "7.2"
+            dependencies: "lowest"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+        with:
+          fetch-depth: 2
+
+      - name: "Install PHP with Xdebug"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "${{ matrix.php-version }}"
+          coverage: "xdebug"
+          ini-values: "zend.assertions=1"
+
+      - name: "Install dependencies with Composer"
+        uses: "ramsey/composer-install@v1"
+        with:
+          dependency-versions: "${{ matrix.dependencies }}"
+          composer-options: "--prefer-dist --no-suggest"
+
+      - name: "Run PHPUnit"
+        run: "vendor/bin/phpunit --coverage-clover=coverage.xml"
+
+      - name: "Upload coverage file"
+        uses: "actions/upload-artifact@v2"
+        with:
+          name: "phpunit-${{ matrix.php-version }}.coverage"
+          path: "coverage.xml"
+
+  upload_coverage:
+    name: "Upload coverage to Codecov"
+    runs-on: "ubuntu-20.04"
+    needs:
+      - "phpunit"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+        with:
+          fetch-depth: 2
+
+      - name: "Download coverage files"
+        uses: "actions/download-artifact@v2"
+        with:
+          path: "reports"
+
+      - name: "Upload to Codecov"
+        uses: "codecov/codecov-action@v1"
+        with:
+          directory: "reports"


### PR DESCRIPTION
Creates a workflow template for a Continuous Integration workflow, which:

- Runs PHPUnit on PHP versions 7.2 - 8.0
- ~Installs Xdebug for code coverage (as PCOV support was introduced in PHPUnit 8 and many projects still use PHPUnit 7)~
- Installs PCOV for code coverage
- Caches Composer dependencies to speed up the build
- Includes a job running on PHP 7.2 which tests the minimum dependency version requirements.
- Uploads coverage information to Codecov

 Based on https://github.com/doctrine/data-fixtures/pull/353, which was in turn based on https://github.com/doctrine/event-manager/pull/34, https://github.com/doctrine/lexer/pull/48, and similar changes in other Doctrine repositories.

~Pending https://github.com/doctrine/.github/pull/16 which discusses the introduction of the [ramsey/composer-install action](https://github.com/marketplace/actions/install-composer-dependencies) to install/update and cache Composer dependencies.~