### PR TITLE
Remove references to master branch

### DIFF
--- a/workflow-templates/coding-standards.yml
+++ b/workflow-templates/coding-standards.yml
@@ -5,11 +5,9 @@ on:
   pull_request:
     branches:
       - "*.x"
-      - "master"
   push:
     branches:
       - "*.x"
-      - "master"
 
 jobs:
   coding-standards:

--- a/workflow-templates/continuous-integration.yml
+++ b/workflow-templates/continuous-integration.yml
@@ -4,11 +4,9 @@ on:
   pull_request:
     branches:
       - "*.x"
-      - "master"
   push:
     branches:
       - "*.x"
-      - "master"
 
 env:
   fail-fast: true

--- a/workflow-templates/static-analysis.yml
+++ b/workflow-templates/static-analysis.yml
@@ -5,11 +5,9 @@ on:
   pull_request:
     branches:
       - "*.x"
-      - "master"
   push:
     branches:
       - "*.x"
-      - "master"
 
 jobs:
   static-analysis-phpstan:


### PR DESCRIPTION
We are supposed to use numbered branches now.