### PR TITLE
Always use composer update

### DIFF
--- a/workflow-templates/coding-standards.yml
+++ b/workflow-templates/coding-standards.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"
+        with:
+          dependency-versions: "highest"
 
       # https://github.com/doctrine/.github/issues/3
       - name: "Run PHP_CodeSniffer"

--- a/workflow-templates/static-analysis.yml
+++ b/workflow-templates/static-analysis.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"
+        with:
+          dependency-versions: "highest"
 
       - name: "Run a static analysis with phpstan/phpstan"
         run: "vendor/bin/phpstan analyse"
@@ -56,6 +58,8 @@ jobs:
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"
+        with:
+          dependency-versions: "highest"
 
       - name: "Run a static analysis with vimeo/psalm"
         run: "vendor/bin/psalm --show-info=false --stats --output-format=github --threads=$(nproc)"


### PR DESCRIPTION
composer.lock has been removed from version control, and now Composer
warns about that.