### PR TITLE
Define required secrets

### DIFF
--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -8,6 +8,17 @@ on:
         default: false
         required: false
         type: "boolean"
+    secrets:
+      GITHUB_TOKEN:
+        required: true
+      SIGNING_SECRET_KEY:
+        required: true
+      GIT_AUTHOR_NAME:
+        required: true
+      GIT_AUTHOR_EMAIL:
+        required: true
+      ORGANIZATION_ADMIN_TOKEN:
+        required: true
 
 jobs:
   release:


### PR DESCRIPTION
Not doing so will result in an error when passing secrets to this
workflow, according to
https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#onworkflow_callsecrets