### PR TITLE
Add support for setting COMPOSER_ROOT_VERSION

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -9,6 +9,10 @@ on:
         default: "8.0"
         required: false
         type: "string"
+      composer-root-version:
+        description: "The version the package being tested, in case of circular dependencies."
+        required: false
+        type: "string"
 
 jobs:
   coding-standards:
@@ -30,6 +34,11 @@ jobs:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
           tools: "cs2pr"
+
+      - name: "Set COMPOSER_ROOT_VERSION"
+        run: |
+          echo "COMPOSER_ROOT_VERSION=${{ inputs.composer-root-version }}" >> $GITHUB_ENV
+        if: "${{ inputs.composer-root-version }}"
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -8,6 +8,10 @@ on:
         default: '["7.2", "7.3", "7.4", "8.0"]'
         required: false
         type: "string"
+      composer-root-version:
+        description: "The version the package being tested, in case of circular dependencies."
+        required: false
+        type: "string"
 
 env:
   fail-fast: true
@@ -47,6 +51,11 @@ jobs:
           php-version: "${{ matrix.php-version }}"
           coverage: "xdebug"
           ini-values: "zend.assertions=1"
+
+      - name: "Set COMPOSER_ROOT_VERSION"
+        run: |
+          echo "COMPOSER_ROOT_VERSION=${{ inputs.composer-root-version }}" >> $GITHUB_ENV
+        if: "${{ inputs.composer-root-version }}"
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -9,6 +9,10 @@ on:
         default: "8.0"
         required: false
         type: "string"
+      composer-root-version:
+        description: "The version the package being tested, in case of circular dependencies."
+        required: false
+        type: "string"
 
 jobs:
   phpstan:
@@ -29,6 +33,11 @@ jobs:
         with:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
+
+      - name: "Set COMPOSER_ROOT_VERSION"
+        run: |
+          echo "COMPOSER_ROOT_VERSION=${{ inputs.composer-root-version }}" >> $GITHUB_ENV
+        if: "${{ inputs.composer-root-version }}"
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"
@@ -56,6 +65,11 @@ jobs:
         with:
           coverage: "none"
           php-version: "${{ matrix.php-version }}"
+
+      - name: "Set COMPOSER_ROOT_VERSION"
+        run: |
+          echo "COMPOSER_ROOT_VERSION=${{ inputs.composer-root-version }}" >> $GITHUB_ENV
+        if: "${{ inputs.composer-root-version }}"
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v1"


### PR DESCRIPTION
Composer needs that variable to be set when the package under test is
depended on by its own dependencies.
This is the case for `doctrine/instantiator` and `phpunit/phpunit`, or with
`doctrine/persistence` and `doctrine/common`, for instance.

Proof that it works: https://github.com/greg0ire/persistence/pull/2