### PR TITLE
Include dependencies setting in coverage file name

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -69,7 +69,7 @@ jobs:
       - name: "Upload coverage file"
         uses: "actions/upload-artifact@v2"
         with:
-          name: "phpunit-${{ matrix.php-version }}.coverage"
+          name: "phpunit-${{ matrix.php-version }}-${{ matrix.dependencies }}.coverage"
           path: "coverage.xml"
 
   upload_coverage:


### PR DESCRIPTION
This avoids a collision between the names of the files for:
- the job with the lowest version of PHP, and the highest version of
  dependencies
- the job with the lowest version of PHP, and the lowest version of
  dependencies

Proof that it works can be seen at https://github.com/doctrine/DoctrineMigrationsBundle/pull/453 (there is an increase in coverage, and [the upload job logs](https://github.com/doctrine/DoctrineMigrationsBundle/runs/4162331073?check_suite_focus=true#step:4:37) show that 5 files were found and uploaded, not just 4).