### PR TITLE
Add workflow to allow testing with unstable Symfony

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -10,7 +10,7 @@ on:
         required: false
         type: "string"
       composer-root-version:
-        description: "The version the package being tested, in case of circular dependencies."
+        description: "The version of the package being tested, in case of circular dependencies."
         required: false
         type: "string"
       composer-options:

--- a/.github/workflows/continuous-integration-symfony-unstable.yml
+++ b/.github/workflows/continuous-integration-symfony-unstable.yml
@@ -1,0 +1,80 @@
+name: "Continuous Integration with unstable Symfony"
+
+on:
+  workflow_call:
+    inputs:
+      php-version:
+        description: "The PHP version to use when running the job"
+        default: "8.0"
+        required: false
+        type: "string"
+      composer-root-version:
+        description: "The version of the package being tested, in case of circular dependencies."
+        required: false
+        type: "string"
+      composer-options:
+        description: "Additional flags for the composer install command."
+        default: "--prefer-dist"
+        required: false
+        type: "string"
+      symfony-version-constraint:
+        description: "The unstable version constraint to enforce "
+        required: true
+        type: "string"
+      extra-requirements:
+        description: "Will be used with composer require --no-update"
+        required: false
+        type: "string"
+
+env:
+  fail-fast: true
+
+jobs:
+  phpunit:
+    name: "PHPUnit"
+    runs-on: "ubuntu-20.04"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v2"
+        with:
+          fetch-depth: 2
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "${{ inputs.php-version }}"
+          coverage: "pcov"
+          ini-values: "zend.assertions=1"
+          tools: "flex"
+
+      - name: "Set COMPOSER_ROOT_VERSION"
+        run: |
+          echo "COMPOSER_ROOT_VERSION=${{ inputs.composer-root-version }}" >> $GITHUB_ENV
+        if: "${{ inputs.composer-root-version }}"
+
+      - name: "Allow unstable dependencies"
+        run: |
+          composer config minimum-stability dev
+          composer config prefer-stable true
+
+      - name: "Require unstable dependencies"
+        run: "composer require --no-update ${{ inputs.extra-requirements }}"
+        if: "${{ inputs.extra-requirements }}"
+
+      - name: "Enforce Symfony version"
+        run: "composer config extra.symfony.require ${{ inputs.symfony-version-constraint }}"
+
+      - name: "Install dependencies with Composer"
+        uses: "ramsey/composer-install@v1"
+        with:
+          dependency-versions: "highest"
+          composer-options: "${{ inputs.composer-options }}"
+
+      - name: "Run PHPUnit"
+        run: "vendor/bin/phpunit --coverage-clover=phpunit-${{ inputs.php-version }}-unstable.coverage"
+
+      - name: "Upload to Codecov"
+        uses: "codecov/codecov-action@v1"
+        with:
+          files: "./phpunit-${{ inputs.php-version }}-unstable.coverage"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -9,7 +9,7 @@ on:
         required: false
         type: "string"
       composer-root-version:
-        description: "The version the package being tested, in case of circular dependencies."
+        description: "The version of the package being tested, in case of circular dependencies."
         required: false
         type: "string"
       composer-options:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -10,7 +10,7 @@ on:
         required: false
         type: "string"
       composer-root-version:
-        description: "The version the package being tested, in case of circular dependencies."
+        description: "The version of the package being tested, in case of circular dependencies."
         required: false
         type: "string"
       composer-options:

--- a/workflow-templates/continuous-integration.yml
+++ b/workflow-templates/continuous-integration.yml
@@ -14,3 +14,13 @@ jobs:
     uses: "doctrine/.github/.github/workflows/continuous-integration.yml@use_a_valid_ref_here"
     with:
       php-versions: '["6.0", "6.1"]' # Use custom versions of PHP
+
+  phpunit-unstable-symfony:
+    name: "PHPUnit with unstable Symfony"
+    uses: "doctrine/.github/.github/workflows/continuous-integration-symfony-unstable.yml@use_a_valid_ref_here"
+    with:
+      php-versions: '["6.0"]' # Use custom version of PHP
+      symfony-version-constraint: "47.1.x"
+
+      # If the package requires some components but does not allow that version yet
+      extra-requirements: "symfony/framework-bundle 47.1.x symfony/console 47.1.x"


### PR DESCRIPTION
It allows for testing with an unstable version of Symfony, and will
prefer stable versions for other packages.
It has two more options than its normal counterpart:
- unstable-requirements allows to force usage of an unstable versions
  for any number of dependencies, but should be used only for Symfony
  packages.
- symfony-version-constraint will be used to force usage of the given
  constraint for all installed Symfony components that are indirectly
  installed.

The intended usage is not just for Symfony bundles, but for any Doctrine package that depends on a Symfony component. I'm not sure if we should use it just before new major versions are release, or do the same thing for minor versions of Symfony as well.

An example usage can be seen at https://github.com/doctrine/DoctrineMigrationsBundle/pull/456

