### PR TITLE
Stop requiring GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -9,8 +9,6 @@ on:
         required: false
         type: "boolean"
     secrets:
-      GITHUB_TOKEN:
-        required: true
       SIGNING_SECRET_KEY:
         required: true
       GIT_AUTHOR_NAME:

--- a/workflow-templates/release-on-milestone-closed.yml
+++ b/workflow-templates/release-on-milestone-closed.yml
@@ -10,7 +10,6 @@ jobs:
     name: "Git tag, release & create merge-up PR"
     uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@use_a_valid_ref_here"
     secrets:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
       GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}
       ORGANIZATION_ADMIN_TOKEN: ${{ secrets.ORGANIZATION_ADMIN_TOKEN }}


### PR DESCRIPTION
This now seems to cause the following error:

> error parsing called workflow
> "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@1.1.1":
> workflow is invalid: secret name `GITHUB_TOKEN` within `workflow_call`
> can not be used since it would collide with system reserved name

Moreover, the documentation states the following:

> When a reusable workflow is triggered by a caller workflow, the github
> context is always associated with the caller workflow. The called
> workflow is automatically granted access to github.token and
> secrets.GITHUB_TOKEN. For more information about the github context, see
> "Context and expression syntax for GitHub Actions."