### PR TITLE
Add "Composer Lint" job to CI pipeline

### DIFF
--- a/.github/workflows/composer-lint.yml
+++ b/.github/workflows/composer-lint.yml
@@ -1,0 +1,37 @@
+
+name: "Composer Lint"
+
+on:
+  workflow_call:
+    inputs:
+      php-version:
+        description: "The PHP version to use when running the job"
+        default: "8.1"
+        required: false
+        type: "string"
+
+jobs:
+  composer-lint:
+    name: "Composer Lint"
+    runs-on: "ubuntu-20.04"
+
+    strategy:
+      matrix:
+        php-version:
+          - "${{ inputs.php-version }}"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v3"
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
+          tools: composer:v2, composer-normalize:2
+        env:
+          COMPOSER_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: "Composer normmalize"
+        run: "composer-normalize --dry-run"

--- a/workflow-templates/composer-lint.properties.json
+++ b/workflow-templates/composer-lint.properties.json
@@ -1,0 +1,11 @@
+{
+    "name": "Composer Lint",
+    "description": "Enforces consistency in the syntax of 'composer.json'",
+    "iconName": "doctrine-logo",
+    "categories": [
+        "PHP"
+    ],
+    "filePatterns": [
+        "^composer\\.json$"
+    ]
+}

--- a/workflow-templates/composer-lint.yml
+++ b/workflow-templates/composer-lint.yml
@@ -1,0 +1,20 @@
+name: "Composer Lint"
+
+on:
+  pull_request:
+    branches:
+      - "*.x"
+    paths:
+      - "composer.json"
+  push:
+    branches:
+      - "*.x"
+    paths:
+      - "composer.json"
+
+jobs:
+  composer-lint:
+    name: "Composer Lint"
+    uses: "doctrine/.github/.github/workflows/composer-lint.yml@use_a_valid_ref_here"
+    with:
+      php-version: "6.0" # use a custom version of PHP


### PR DESCRIPTION
Follows https://github.com/doctrine/DoctrineBundle/pull/1540#issuecomment-1161757390.

I was not able to leverage the [Coding Standards workflow]( https://github.com/phansys/doctrine.github/blob/9740cba8d0ce280768b7e0fa56dc65b143850531/.github/workflows/coding-standards.yml#L2) as I think (currently) [there is no simple way to filter a single job](https://github.community/t/path-filtering-for-jobs-and-steps/16447).