### PR TITLE
Run tools on PHP 8.2

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -6,7 +6,7 @@ on:
     inputs:
       php-version:
         description: "The PHP version to use when running the job"
-        default: "8.1"
+        default: "8.2"
         required: false
         type: "string"
       composer-root-version:

--- a/.github/workflows/composer-lint.yml
+++ b/.github/workflows/composer-lint.yml
@@ -6,7 +6,7 @@ on:
     inputs:
       php-version:
         description: "The PHP version to use when running the job"
-        default: "8.1"
+        default: "8.2"
         required: false
         type: "string"
 

--- a/.github/workflows/continuous-integration-symfony-unstable.yml
+++ b/.github/workflows/continuous-integration-symfony-unstable.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       php-version:
         description: "The PHP version to use when running the job"
-        default: "8.1"
+        default: "8.2"
         required: false
         type: "string"
       composer-root-version:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -5,7 +5,7 @@ on:
     inputs:
       php-versions:
         description: "The PHP versions to use when running the job"
-        default: '["7.2", "7.3", "7.4", "8.0", "8.1"]'
+        default: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2"]'
         required: false
         type: "string"
       composer-root-version:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -6,7 +6,7 @@ on:
     inputs:
       php-version:
         description: "The PHP version to use when running the job"
-        default: "8.1"
+        default: "8.2"
         required: false
         type: "string"
       composer-root-version:


### PR DESCRIPTION
PHP 8.2 has been released. Let's use that version to run our CI tools.