### PR TITLE
Use paths in templates

### DIFF
--- a/workflow-templates/coding-standards.yml
+++ b/workflow-templates/coding-standards.yml
@@ -5,9 +5,21 @@ on:
   pull_request:
     branches:
       - "*.x"
+    paths:
+      - ".github/workflows/coding-standards.yml"
+      - "composer.*"
+      - "src/**" # but some packages use lib
+      - "phpcs.xml.dist"
+      - "tests/**"
   push:
     branches:
       - "*.x"
+    paths:
+      - ".github/workflows/coding-standards.yml"
+      - "composer.*"
+      - "src/**" # but some packages use lib
+      - "phpcs.xml.dist"
+      - "tests/**"
 
 jobs:
   coding-standards:

--- a/workflow-templates/composer-lint.yml
+++ b/workflow-templates/composer-lint.yml
@@ -5,11 +5,13 @@ on:
     branches:
       - "*.x"
     paths:
+      - ".github/workflows/composer-lint.yml"
       - "composer.json"
   push:
     branches:
       - "*.x"
     paths:
+      - ".github/workflows/composer-lint.yml"
       - "composer.json"
 
 jobs:

--- a/workflow-templates/continuous-integration.yml
+++ b/workflow-templates/continuous-integration.yml
@@ -4,9 +4,21 @@ on:
   pull_request:
     branches:
       - "*.x"
+    paths:
+      - ".github/workflows/continuous-integration.yml"
+      - "composer.*"
+      - "src/**" # but some packages use lib
+      - "phpunit.xml.dist"
+      - "tests/**"
   push:
     branches:
       - "*.x"
+    paths:
+      - ".github/workflows/continuous-integration.yml"
+      - "composer.*"
+      - "src/**" # but some packages use lib
+      - "phpunit.xml.dist"
+      - "tests/**"
 
 jobs:
   phpunit:

--- a/workflow-templates/static-analysis.yml
+++ b/workflow-templates/static-analysis.yml
@@ -5,9 +5,23 @@ on:
   pull_request:
     branches:
       - "*.x"
+    paths:
+      - ".github/workflows/static-analysis.yml"
+      - "composer.*"
+      - "src/**" # but some packages use lib
+      - "phpstan*"
+      - "psalm*"
+      - "tests/**"
   push:
     branches:
       - "*.x"
+    paths:
+      - ".github/workflows/static-analysis.yml"
+      - "composer.*"
+      - "src/**" # but some packages use lib
+      - "phpstan*"
+      - "psalm*"
+      - "tests/**"
 
 jobs:
   static-analysis:


### PR DESCRIPTION
It is good not to run jobs unless needed, and it can be tricky to do so, so let us document that in a centralized place.