### PR TITLE
Pass CODECOV_TOKEN to codecov/codecov-action

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -98,3 +98,5 @@ jobs:
         uses: "codecov/codecov-action@v4"
         with:
           directory: "reports"
+        env:
+          CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"


### PR DESCRIPTION
According to the Codecov documentation, "token-less uploading is only available to forks attempting to create PRs on public repositories", and we need to be able to run builds after merging, or for PRs from a doctrine repository to itself (typically, a merge up).

See https://docs.codecov.com/docs/codecov-uploader#supporting-token-less-uploads-for-forks-of-open-source-repos-using-codecov