### PR TITLE
Remove quotes

### DIFF
--- a/workflow-templates/continuous-integration.yml
+++ b/workflow-templates/continuous-integration.yml
@@ -27,7 +27,7 @@ jobs:
     with:
       php-versions: '["6.0", "6.1"]' # Use custom versions of PHP
     secrets:
-      CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   phpunit-unstable-symfony:
     name: "PHPUnit with unstable Symfony"
@@ -39,4 +39,4 @@ jobs:
       # If the package requires some components but does not allow that version yet
       extra-requirements: "symfony/framework-bundle 47.1.x symfony/console 47.1.x"
     secrets:
-      CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
In the case of a pull request made from a fork, secrets are not accessible, and this resolved to null.
The codecov action seems to interpret null as no secret provided, while it interprets the empty string as an invalid token, making the whole tokenless upload invalid.