### PR TITLE
Implement documentation action

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,46 @@
+
+name: "Documentation"
+
+on:
+  workflow_call:
+
+jobs:
+  guides:
+    name: "phpDocumentor Guides"
+    runs-on: "ubuntu-22.04"
+
+    strategy:
+      matrix:
+        php-version:
+          - "8.3" # Use the same version as in doctrine/doctrine-website
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v4"
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          coverage: "none"
+          php-version: "${{ matrix.php-version }}"
+          tools: "cs2pr"
+
+      # Some of our dependencies have supported branches where they still need
+      # to support PHP < 8.1. For that reason, let us not even attempt to install
+      # the usual dependencies and start from scratch.
+      - name: "Remove existing composer file"
+        run: "rm composer.json"
+
+      - name: "Require phpdocumentor/guides-cli"
+        # We use the same version constraint as in doctrine/doctrine-website
+        run: "composer require --dev phpdocumentor/guides-cli '^1.4' --no-update"
+
+      - name: "Install dependencies with Composer"
+        uses: "ramsey/composer-install@v3"
+        with:
+          dependency-versions: "highest"
+          composer-options: "${{ inputs.composer-options }}"
+
+      - name: "Run guides"
+        run: |
+          vendor/bin/guides -vvv --no-progress --fail-on-log docs/en

--- a/workflow-templates/documentation.properties.json
+++ b/workflow-templates/documentation.properties.json
@@ -1,0 +1,11 @@
+{
+    "name": "Documentation",
+    "description": "Validates the documentation",
+    "iconName": "doctrine-logo",
+    "categories": [
+        "RST"
+    ],
+    "filePatterns": [
+        "^guides\\.xml$"
+    ]
+}

--- a/workflow-templates/documentation.yml
+++ b/workflow-templates/documentation.yml
@@ -1,0 +1,21 @@
+
+name: "Documentation"
+
+on:
+  pull_request:
+    branches:
+      - "*.x"
+    paths:
+      - ".github/workflows/documentation.yml"
+      - "docs/**"
+  push:
+    branches:
+      - "*.x"
+    paths:
+      - ".github/workflows/documentation.yml"
+      - "docs/**"
+
+jobs:
+  documentation:
+    name: "Documentation"
+    uses: "doctrine/.github/.github/workflows/documentation.yml@use_a_valid_ref_here"


### PR DESCRIPTION
I did not make anything configurable because the right versions to use depend more on doctrine/doctrine-website than on the consuming project itself.

- [It fails when it should](https://github.com/greg0ire/annotations/pull/2).
- [It succeeds when it should](https://github.com/greg0ire/annotations/pull/3)

On repositories that still need to support PHP < 8.1:
- We can and should use this action.
- We should require `phpDocumentor/guides` on branches that require at least PHP 8.1, so that contributors can run the tool locally.