### PR TITLE
Split static analysis workflow

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -1,5 +1,5 @@
 
-name: "Static Analysis"
+name: "Static Analysis with PHPStan"
 
 on:
   workflow_call:
@@ -21,15 +21,7 @@ on:
 
 jobs:
   phpstan:
-    name: "PHPStan (deprecated in favor of phpstan.yml)"
-    uses: "./.github/workflows/phpstan.yml"
-    with:
-      php-version: "${{ inputs.php-version }}"
-      composer-root-version: "${{ inputs.composer-root-version }}"
-      composer-options: "${{ inputs.composer-options }}"
-
-  psalm:
-    name: "Psalm (PHP: ${{ inputs.php-version }}, deprecated without a replacement)"
+    name: "PHPStan (PHP: ${{ inputs.php-version }})"
     runs-on: "ubuntu-22.04"
 
     steps:
@@ -53,5 +45,5 @@ jobs:
           dependency-versions: "highest"
           composer-options: "${{ inputs.composer-options }}"
 
-      - name: "Run a static analysis with vimeo/psalm"
-        run: "vendor/bin/psalm --show-info=false --stats --output-format=github --threads=$(nproc)"
+      - name: "Run a static analysis with phpstan/phpstan"
+        run: "vendor/bin/phpstan analyse -v"

--- a/workflow-templates/phpstan.properties.json
+++ b/workflow-templates/phpstan.properties.json
@@ -1,12 +1,11 @@
 {
-    "name": "Static analysis",
+    "name": "Static analysis with PHPStan",
     "description": "Perform static analysis on the source code and tests",
     "iconName": "doctrine-logo",
     "categories": [
         "PHP"
     ],
     "filePatterns": [
-        "^phpstan\\.neon(?:\\.dist)$",
-        "^psalm\\.xml$"
+        "^phpstan\\.neon(?:\\.dist)$"
     ]
 }

--- a/workflow-templates/phpstan.yml
+++ b/workflow-templates/phpstan.yml
@@ -6,21 +6,19 @@ on:
     branches:
       - "*.x"
     paths:
-      - ".github/workflows/static-analysis.yml"
+      - ".github/workflows/phpstan.yml"
       - "composer.*"
       - "src/**"
       - "phpstan*"
-      - "psalm*"
       - "tests/**"
   push:
     branches:
       - "*.x"
     paths:
-      - ".github/workflows/static-analysis.yml"
+      - ".github/workflows/phpstan.yml"
       - "composer.*"
       - "src/**"
       - "phpstan*"
-      - "psalm*"
       - "tests/**"
 
 jobs:


### PR DESCRIPTION
This should allow downstream projects to better prepare for the Psalm removal: they can use the new phpstan workflow whenever they want to drop Psalm, and when all of them do, then we can drop the static analysis workflow form this repository.

Proof that it does not break the old workflow: https://github.com/greg0ire/collections/pull/2
Proof that the new workflow works: https://github.com/greg0ire/collections/pull/3