### PR TITLE
Add global issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug.md
+++ b/.github/ISSUE_TEMPLATE/Bug.md
@@ -1,0 +1,37 @@
+---
+name: 🐞 Bug Report
+about: Something is broken? 🔨
+---
+
+### Bug Report
+
+<!-- Fill in the relevant information below to help triage your issue. -->
+
+|    Q                                        |   A
+|-------------------------------------------- | ------
+| Version                                     | x.y.z
+| Previous Version if the bug is a regression | x.y.z
+
+#### Summary
+
+<!-- Provide a summary describing the problem you are experiencing. -->
+
+#### Current behavior
+
+<!-- What is the current (buggy) behavior? -->
+
+#### Expected behavior
+
+<!-- What was the expected (correct) behavior? -->
+
+#### How to reproduce
+
+<!--
+Provide a failing Unit or Functional Test - you can submit one in a Pull
+Request separately, referencing this bug report. And if you feel like it, why
+not fix the bug while you're at it?
+If that is too difficult, provide a link to a minimal repository containing an
+application that reproduces the bug.
+If the bug is simple, you may provide a code snippet instead, or even a list of
+steps.
+-->

--- a/.github/ISSUE_TEMPLATE/Feature_Request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_Request.md
@@ -1,0 +1,24 @@
+---
+name: 🎉 Feature Request
+about: You have a neat idea that should be implemented? 🎩
+---
+
+### Feature Request
+
+#### What
+
+<!--
+Describe the behavior you would like to see.
+-->
+
+#### Why
+
+<!--
+Explain why you believe this feature should be implemented.
+-->
+
+#### How
+
+<!--
+If you have an idea on how to implement this feature technically, please share it.
+-->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+contact_links:
+  - name: Doctrine Slack
+    url: https://www.doctrine-project.org/slack
+    about: Join the Doctrine Slack to chat with other Doctrine users and contributors.
+  - name: Doctrine channel on Symfony Slack
+    url: https://symfony-devs.slack.com/messages/C3FQPE6LE/
+    about: 'Communicate with other Symfony developers that use Doctrine in the #doctrine slack channel in the Symfony Devs slack instance.'
+  - name: Laravel Slack
+    url: http://slack.laraveldoctrine.org/
+    about: Communicate with other Laravel developers that use Doctrine in the Laravel Doctrine slack instance.


### PR DESCRIPTION
We also have PR templates at least in ORM, but I do not think they are used at all, since you have to add a `?template=the_template.md` parameter to enable them.