### PR TITLE
Website JSON schema for .doctrine-project.json

### DIFF
--- a/.github/workflows/website-schema.yml
+++ b/.github/workflows/website-schema.yml
@@ -1,0 +1,18 @@
+name: "Website config validation"
+
+on:
+  workflow_call:
+
+jobs:
+  schema:
+    runs-on: "ubuntu-24.04"
+
+    steps:
+      - name: "Checkout code"
+        uses: "actions/checkout@v4"
+
+      - name: "Fetch JSON schema"
+        run: "wget https://www.doctrine-project.org/schema/website-schema.json --output-document website-schema.json"
+
+      - name: "Validate JSON schema"
+        run: "jsonschema website-schema.json --instance .doctrine-project.json"

--- a/workflow-templates/website-schema.yml
+++ b/workflow-templates/website-schema.yml
@@ -1,0 +1,21 @@
+
+name: "Website config validation"
+
+on:
+  pull_request:
+    branches:
+      - "*.x"
+    paths:
+      - ".doctrine-project.json"
+      - ".github/workflows/website-schema.yml"
+  push:
+    branches:
+      - "*.x"
+    paths:
+      - ".doctrine-project.json"
+      - ".github/workflows/website-schema.yml"
+
+jobs:
+  json-validate:
+    name: "Validate JSON schema"
+    uses: "doctrine/.github/.github/workflows/website-schema.yml@use_a_valid_ref_here"


### PR DESCRIPTION
To make changes in the `.doctrine-project.json` files simpler I've created a JSON schema for it. The current problem is the sharing of the schema-file in the workflows of the other repositories. They need to download `website-schema.json` in their workflows to be able to run it against their website config file. 
Downloading files from GitHub seem to need a token and `GITHUB_TOKEN` can't be used between repositories of an organisation. My suggestion would be to move the schema to doctrine/doctrine-website. Or does anyone have another suggestion?