### PR TITLE
Allow locking the deps

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -13,6 +13,11 @@ on:
         description: "The version of the package being tested, in case of circular dependencies."
         required: false
         type: "string"
+      composer-dependency-versions:
+        description: "whether the job should install the locked, highest, or lowest versions of Composer dependencies."
+        default: "highest"
+        required: false
+        type: "string"
       composer-options:
         description: "Additional flags for the composer install command."
         default: "--prefer-dist"
@@ -43,7 +48,7 @@ jobs:
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v3"
         with:
-          dependency-versions: "highest"
+          dependency-versions: "${{ inputs.composer-dependency-versions }}"
           composer-options: "${{ inputs.composer-options }}"
 
       # https://github.com/doctrine/.github/issues/3

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -13,6 +13,11 @@ on:
         description: "The version of the package being tested, in case of circular dependencies."
         required: false
         type: "string"
+      composer-dependency-versions:
+        description: "whether the job should install the locked, highest, or lowest versions of Composer dependencies."
+        default: "highest"
+        required: false
+        type: "string"
       composer-options:
         description: "Additional flags for the composer install command."
         default: "--prefer-dist"
@@ -42,7 +47,7 @@ jobs:
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v3"
         with:
-          dependency-versions: "highest"
+          dependency-versions: "${{ inputs.composer-dependency-versions }}"
           composer-options: "${{ inputs.composer-options }}"
 
       - name: "Run a static analysis with phpstan/phpstan"


### PR DESCRIPTION
On `doctrine/website`, which is a regular Symfony application, we put the `composer.lock` under version control, as we should. In order to be able to have the same experience in the CI as we have locally, we should use the same version of the dependencies. To that end, let's allow passing the `dependency-versions` option to `ramsey/composer-install` on workflows that are reused on `doctrine/website` .

## Proofs

We can see that the option is taken into account in the following logs:

- [for coding-standards](https://github.com/doctrine/doctrine-website/actions/runs/13061141050/job/36444178551?pr=654#step:5:3);
- [for phpstan](https://github.com/doctrine/doctrine-website/actions/runs/13061141055/job/36444178563?pr=654#step:5:3).