### PR TITLE
fix: pin phpDocumentor

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -27,8 +27,12 @@ jobs:
         run: "rm composer.json"
 
       - name: "Require phpdocumentor/guides-cli"
-        # We use the same version constraint as in doctrine/doctrine-website
-        run: "composer require --dev phpdocumentor/guides-cli '^1.4' --no-update"
+        # We use the same versions as in doctrine/doctrine-website
+        run: >
+          composer require --dev
+          phpdocumentor/guides-cli:1.7.0
+          phpdocumentor/filesystem:1.7.0
+          --no-update
 
       - name: "Install dependencies with Composer"
         uses: "ramsey/composer-install@v3"


### PR DESCRIPTION
Sudden upgrades can lead to broken builds. For instance, the latest versions require us to install `phpDocumentor/filesystem`. Let us do the upgrades in a controlled way from time to time instead.

Proof: https://github.com/doctrine/orm/pull/11818