### PR TITLE
Report all CS errors to CI console

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -54,5 +54,5 @@ jobs:
       # https://github.com/doctrine/.github/issues/3
       - name: "Run PHP_CodeSniffer"
         run: |
-          vendor/bin/phpcs -q --report=diff || true
+          vendor/bin/phpcs -q --report-emacs --report-diff || true
           vendor/bin/phpcs -q --no-colors --report=checkstyle | cs2pr


### PR DESCRIPTION
In https://github.com/doctrine/.github/pull/45 PR I have added "diff format" output of CS fixes. This works well and I love it!

However, "diff format" outputs only changes that can be autofixed.

Thanks to https://github.com/squizlabs/PHP_CodeSniffer/wiki/Reporting#printing-multiple-reports multiple reports can be output in a single run.

This PR adds "emacs format" output to display all CS errors incl. the non-autofixable ones.

Example "emacs format" output:

```
Tests\ORM\Internal\TopologicalSortTest.php:319:13: error - You must use "/**" style comments for a function
    comment (Squiz.Commenting.FunctionComment.WrongStyle)
```

With this PR all CS errors can be understood from the CI output perfectly.