### PR TITLE
Remove CI label

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,5 +4,3 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    labels:
-      - "CI"


### PR DESCRIPTION
With dependabot, we are not maintaining the CI of this repository, we are instead affecting workflows that will be used in our ecosystem of libraries. A "CI" label would be misleading.

Plus, we do not have automatic releases setup here, and probably never will, so there is little point in having labels.