### PR TITLE
Drop -q option when using phpcs

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -51,8 +51,7 @@ jobs:
           dependency-versions: "${{ inputs.composer-dependency-versions }}"
           composer-options: "${{ inputs.composer-options }}"
 
-      # https://github.com/doctrine/.github/issues/3
       - name: "Run PHP_CodeSniffer"
         run: |
-          vendor/bin/phpcs -q --report-emacs --report-diff || true
-          vendor/bin/phpcs -q --no-colors --report=checkstyle | cs2pr
+          vendor/bin/phpcs --report-emacs --report-diff || true
+          vendor/bin/phpcs --no-colors --report=checkstyle | cs2pr


### PR DESCRIPTION
It was initially used because phpcs wrongly output things not intended to be piped into other programs to stdout, such as the progress bar and timing information.


Closes #3 

Note that this is a breaking change, because it requires using PHPCS v4+ (which in turn will require to upgrade to `doctrine/coding-standard` 14)