### PR TITLE
Use development file

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -37,6 +37,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
+          ini-file: development
           php-version: "${{ inputs.php-version }}"
           tools: "cs2pr"
 

--- a/.github/workflows/composer-lint.yml
+++ b/.github/workflows/composer-lint.yml
@@ -23,6 +23,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
+          ini-file: development
           php-version: "${{ inputs.php-version }}"
           tools: composer:v2, composer-normalize:2
         env:

--- a/.github/workflows/continuous-integration-symfony-unstable.yml
+++ b/.github/workflows/continuous-integration-symfony-unstable.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           php-version: "${{ inputs.php-version }}"
           coverage: "pcov"
-          ini-values: "zend.assertions=1"
+          ini-file: development
           tools: "flex"
 
       - name: "Set COMPOSER_ROOT_VERSION"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: "pcov"
-          ini-values: "zend.assertions=1"
+          ini-file: development
 
       - name: "Install PHP with XDebug"
         uses: "shivammathur/setup-php@v2"
@@ -58,7 +58,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           coverage: "xdebug"
-          ini-values: "zend.assertions=1"
+          ini-file: development
 
       - name: "Set COMPOSER_ROOT_VERSION"
         run: |

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,6 +17,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
+          ini-file: development
           php-version: "8.3" # Use the same version as in doctrine/doctrine-website
           tools: "cs2pr"
 

--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -37,6 +37,7 @@ jobs:
         uses: "shivammathur/setup-php@v2"
         with:
           coverage: "none"
+          ini-file: development
           php-version: "${{ inputs.php-version }}"
 
       - name: "Set COMPOSER_ROOT_VERSION"


### PR DESCRIPTION
It seems that recent versions of PHPUnit have started honoring display_errors. This prompted me to do this more global change, which means we no longer mean to turn assertions on manually, since that is done in the development INI file.

Proof that it still works: https://github.com/doctrine/collections/pull/475
Proof that the underlying change should address the issue: https://github.com/doctrine/DoctrineBundle/pull/2069#issuecomment-3391215747