### PR TITLE
Fix version checking

### DIFF
--- a/.github/workflows/continuous-integration-symfony-unstable.yml
+++ b/.github/workflows/continuous-integration-symfony-unstable.yml
@@ -76,9 +76,7 @@ jobs:
 
       - name: "Check PHP configuration"
         run: >
-          if vendor/bin/phpunit --atleast-version 12.3.1 > /dev/null ||
-             vendor/bin/phpunit --atleast-version 11.5.29 > /dev/null ||
-             vendor/bin/phpunit --atleast-version 10.5.49 > /dev/null; then
+          if vendor/bin/phpunit --atleast-version 10.0.0; then
             vendor/bin/phpunit --check-php-configuration;
           fi
 

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -73,9 +73,7 @@ jobs:
 
       - name: "Check PHP configuration"
         run: >
-          if vendor/bin/phpunit --atleast-version 12.3.1 > /dev/null ||
-             vendor/bin/phpunit --atleast-version 11.5.29 > /dev/null ||
-             vendor/bin/phpunit --atleast-version 10.5.49 > /dev/null; then
+          if vendor/bin/phpunit --atleast-version 10.0.0 > /dev/null; then
             vendor/bin/phpunit --check-php-configuration;
           fi
 


### PR DESCRIPTION
I intended to exclude e.g. 11.5.28 but failed to do so because it is greater than 10.5.49.

Let us instead just check against 10.0.0: if the upgrade fails, it
should be easy to fix it by requiring the correct patch version.

- [with 12.3.1](https://github.com/doctrine/collections/actions/runs/18464377346/job/52602769618?pr=476#step:7:17) :heavy_check_mark: 
- [with 12.2](https://github.com/doctrine/inflector/actions/runs/18464380459/job/52602778562?pr=307) :x: (it should fail)
- [with 9](https://github.com/doctrine/common/pull/1034) :heavy_check_mark: it does not fail